### PR TITLE
fix(studies): let DB generate id by omitting null id on upsert for st…

### DIFF
--- a/src/repositories/bibleStudiesRepository.js
+++ b/src/repositories/bibleStudiesRepository.js
@@ -108,6 +108,11 @@ export const bibleStudiesRepository = {
         updated_at: new Date().toISOString(),
       };
 
+      // Allow DB default (generated uuid) when creating a new row
+      if (!payload.id) {
+        delete payload.id;
+      }
+
       const { data, error } = await supabase
         .from('bible_studies')
         .upsert(payload)
@@ -140,6 +145,11 @@ export const bibleStudiesRepository = {
         ...lesson,
         updated_at: new Date().toISOString(),
       };
+
+      // Allow DB default (generated uuid) when creating a new row
+      if (!payload.id) {
+        delete payload.id;
+      }
 
       const { data, error } = await supabase
         .from('bible_study_lessons')


### PR DESCRIPTION
…udies and lessons\n\n- Delete falsy id before upsert in upsertStudy and upsertLesson\n- Prevents Postgres NOT NULL violation on id and uses default uuid_generate_v4()\n\nDroid-assisted change